### PR TITLE
Fixes on docs and stats.json filename

### DIFF
--- a/projects/scully-disable-angular/README.md
+++ b/projects/scully-disable-angular/README.md
@@ -49,7 +49,7 @@ Now build your app with the `--stats-json` flag enabled as the plugin needs to k
 have been build for your app. Then just run the Scully command.
 
 ```shell script
-npm run build --prod --stats-json
+npm run build -- --prod --stats-json
 npm run scully
 ```
 

--- a/projects/scully-disable-angular/src/lib/index.ts
+++ b/projects/scully-disable-angular/src/lib/index.ts
@@ -21,7 +21,7 @@ const disableAngularPlugin = async (html) => {
 
   if (!existsSync(statsJsonPath)) {
     const noStatsJsonError = `A ${isEs5Config ? 'stats' : 'stats-es2015'}.json is required for the 'disableAngular' plugin.
-Please run 'npm build' with the '--stats-json' flag`;
+Please run 'ng build' with the '--stats-json' flag`;
     console.error(noStatsJsonError);
     throw new Error(noStatsJsonError);
   }


### PR DESCRIPTION
I'm testing your lib and found 2 littles points to fix.

After build my app with Angular CLI 9.0.0-rc.12, the **stats.json** was generated with es2015 suffix, i think can be related with this issue https://github.com/angular/angular-cli/issues/15719

I'm very excited to use Scully for some projects :)