### PR TITLE
Fix scully-plugin-disable-angular in latest Scully version

### DIFF
--- a/projects/scully-plugin-disable-angular/src/lib/index.ts
+++ b/projects/scully-plugin-disable-angular/src/lib/index.ts
@@ -1,4 +1,4 @@
-import { getPluginConfig, HandledRoute, registerPlugin, scullyConfig } from '@scullyio/scully';
+import {getMyConfig, HandledRoute, registerPlugin, scullyConfig} from '@scullyio/scully';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
@@ -17,7 +17,7 @@ const escapeRegExp = (string): string => {
 };
 
 const disableAngularPlugin = (html: string, route: HandledRoute): Promise<string> => {
-  const disableAngularOptions = getPluginConfig<DisableAngularOptions>(DisableAngular, 'render');
+  const disableAngularOptions = getMyConfig<DisableAngularOptions>(disableAngularPlugin);
 
   if (disableAngularOptions.ignoreRoutes && disableAngularOptions.ignoreRoutes.includes(route.route)) {
     return Promise.resolve(html);


### PR DESCRIPTION
In scully 1.1.0 the DisableAngular plugin fails with error message 

```
Plugin "disableAngular" of type "render" is not found, can not store config
```

This is due to the use of `getPluginConfig` which needs to be `getMyConfig`. This PR updates the plugin to use `getMyConfig` and fixes https://github.com/samvloeberghs/kwerri-oss/issues/51#issuecomment-819481374.